### PR TITLE
Yarn offline compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "ejs-mate": "duereg/ejs-mate"
+    "ejs-mate": "git+ssh://git@github.com:duereg/ejs-mate.git"
   },
   "devDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
The current way the dependency is specified does not work when trying to download the module and use it with `yarn install --offline`. This should fix it.